### PR TITLE
fix(ci): add committed example config for distribution archives

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -305,7 +305,7 @@ jobs:
           fi
 
           # Bundle supporting files
-          cp deploy/pkg/config.yml "staging/${ARCHIVE_NAME}/config.yml.example"
+          cp deploy/pkg/config.yml.example "staging/${ARCHIVE_NAME}/config.yml.example"
           cp README.md LICENSE "staging/${ARCHIVE_NAME}/"
 
           # Create archive

--- a/deploy/pkg/config.yml.example
+++ b/deploy/pkg/config.yml.example
@@ -1,0 +1,191 @@
+# =============================================================================
+# Chef Migration Metrics — Example Configuration
+# =============================================================================
+# Copy this file to config.yml and edit it for your environment.
+#
+#   cp config.yml.example config.yml
+#
+# =============================================================================
+
+# ---------------------------------------------------------------------------
+# Chef Server Organisations
+# ---------------------------------------------------------------------------
+# Add one entry per Chef Infra Server organisation you want to collect from.
+organisations:
+  - name: my-org
+    chef_server_url: https://chef.example.com/organizations/my-org
+    org_name: my-org
+    client_name: chef-migration-metrics
+    client_key_path: /etc/chef-migration-metrics/keys/my-org.pem
+
+  # Additional organisations:
+  # - name: another-org
+  #   chef_server_url: https://chef.example.com/organizations/another-org
+  #   org_name: another-org
+  #   client_name: chef-migration-metrics
+  #   client_key_path: /etc/chef-migration-metrics/keys/another-org.pem
+
+  # Database-stored key (requires CMM_CREDENTIAL_ENCRYPTION_KEY env var):
+  # - name: staging
+  #   chef_server_url: https://chef.example.com/organizations/staging
+  #   org_name: staging
+  #   client_name: chef-migration-metrics
+  #   client_key_credential: staging-key
+
+# ---------------------------------------------------------------------------
+# Target Chef Client Versions
+# ---------------------------------------------------------------------------
+# The versions of Chef Infra Client you are upgrading to. Cookbook
+# compatibility is tested against each version listed here.
+target_chef_versions:
+  - "18.5.0"
+  # - "19.0.0"
+
+# ---------------------------------------------------------------------------
+# Datastore
+# ---------------------------------------------------------------------------
+# PostgreSQL connection string. Set via the DATABASE_URL environment variable
+# or uncomment and edit the url line below.
+# datastore:
+#   url: "${DATABASE_URL}"
+
+# ---------------------------------------------------------------------------
+# Git Base URLs (optional)
+# ---------------------------------------------------------------------------
+# If your cookbooks are in git repositories, list the base URLs here.
+# The collector tries each base URL when looking for a cookbook's repo.
+# git_base_urls:
+#   - https://github.com/my-org
+#   - https://gitlab.example.com/chef-cookbooks
+
+# ---------------------------------------------------------------------------
+# Collection Schedule
+# ---------------------------------------------------------------------------
+collection:
+  # Cron expression — default: every hour at minute 0.
+  schedule: "0 * * * *"
+  stale_node_threshold_days: 7
+  stale_cookbook_threshold_days: 365
+
+# ---------------------------------------------------------------------------
+# Concurrency
+# ---------------------------------------------------------------------------
+concurrency:
+  organisation_collection: 5
+  node_page_fetching: 10
+  git_pull: 10
+  cookstyle_scan: 8
+  test_kitchen_run: 4
+  readiness_evaluation: 20
+
+# ---------------------------------------------------------------------------
+# Readiness
+# ---------------------------------------------------------------------------
+readiness:
+  min_free_disk_mb: 2048
+
+# ---------------------------------------------------------------------------
+# Analysis Tools
+# ---------------------------------------------------------------------------
+# If you installed via the native package (RPM/DEB), CookStyle and Test
+# Kitchen are under the embedded prefix. If you are running the standalone
+# binary, leave embedded_bin_dir empty to use PATH lookup.
+analysis_tools:
+  embedded_bin_dir: ""
+  cookstyle_timeout_minutes: 10
+  test_kitchen_timeout_minutes: 30
+
+# ---------------------------------------------------------------------------
+# Web Server
+# ---------------------------------------------------------------------------
+server:
+  listen_address: "0.0.0.0"
+  port: 8080
+  tls:
+    mode: "off"
+    # mode: "auto"   # Automatic TLS via Let's Encrypt (ACME)
+    # mode: "manual"
+    # cert_file: /etc/chef-migration-metrics/tls/cert.pem
+    # key_file:  /etc/chef-migration-metrics/tls/key.pem
+  websocket:
+    enabled: true
+    max_connections: 100
+    send_buffer_size: 64
+    write_timeout_seconds: 10
+    ping_interval_seconds: 30
+    pong_timeout_seconds: 60
+  graceful_shutdown_seconds: 30
+
+# ---------------------------------------------------------------------------
+# Frontend
+# ---------------------------------------------------------------------------
+frontend:
+  base_path: "/"
+
+# ---------------------------------------------------------------------------
+# Exports (optional)
+# ---------------------------------------------------------------------------
+exports:
+  output_directory: /var/lib/chef-migration-metrics/exports
+  max_rows: 100000
+  async_threshold: 5000
+  retention_hours: 24
+
+# ---------------------------------------------------------------------------
+# Elasticsearch / NDJSON Export (optional)
+# ---------------------------------------------------------------------------
+# elasticsearch:
+#   enabled: false
+#   output_directory: /var/lib/chef-migration-metrics/elasticsearch
+#   retention_hours: 48
+
+# ---------------------------------------------------------------------------
+# Notifications (optional)
+# ---------------------------------------------------------------------------
+# notifications:
+#   channels:
+#     - name: slack-ops
+#       type: webhook
+#       url_env: SLACK_WEBHOOK_URL
+#       events:
+#         - collection_complete
+#         - readiness_milestone
+#     - name: email-team
+#       type: email
+#       recipients:
+#         - chef-team@example.com
+#       events:
+#         - collection_failed
+#         - certificate_expiry_warning
+
+# ---------------------------------------------------------------------------
+# SMTP (required for email notifications)
+# ---------------------------------------------------------------------------
+# smtp:
+#   host: smtp.example.com
+#   port: 587
+#   username_env: SMTP_USERNAME
+#   password_env: SMTP_PASSWORD
+#   from_address: chef-migration-metrics@example.com
+#   tls: true
+
+# ---------------------------------------------------------------------------
+# Authentication (optional — defaults to no auth)
+# ---------------------------------------------------------------------------
+# auth:
+#   session_secret_env: CMM_SESSION_SECRET
+#   session_lifetime_hours: 24
+#   providers:
+#     - type: local
+#     - type: ldap
+#       host: ldap.example.com
+#       port: 636
+#       base_dn: "ou=users,dc=example,dc=com"
+#       bind_dn: "cn=service-account,dc=example,dc=com"
+#       bind_password_env: LDAP_BIND_PASSWORD
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+logging:
+  level: INFO


### PR DESCRIPTION
## Problem

The `build-archives` job in the release workflow fails with:

```
cp: cannot stat 'deploy/pkg/config.yml': No such file or directory
```

`deploy/pkg/config.yml` is listed in `.gitignore` because it contains local development credentials (Chef server URL, username, key path, Postgres password). It is never committed, so the CI runner can't find it.

## Fix

- **Add `deploy/pkg/config.yml.example`** — a sanitized, generic example configuration with placeholder values that is safe to commit and ship in distribution archives.
- **Update `.github/workflows/release.yml`** — change the `cp` source from `deploy/pkg/config.yml` to `deploy/pkg/config.yml.example`.

## Notes

The datastore section in the example config uses a commented-out `${DATABASE_URL}` reference rather than an inline placeholder password, to avoid tripping the pre-commit secret detection hook.