### PR TITLE
fix: use correct go build path for RPM/DEB packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,7 +201,7 @@ jobs:
         run: |
           GOARCH=${{ matrix.arch }} CGO_ENABLED=0 GOOS=linux go build \
             -ldflags "-X main.version=${VERSION} -X main.commit=${GIT_COMMIT} -X main.buildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            -o build/chef-migration-metrics .
+            -o build/chef-migration-metrics ./cmd/chef-migration-metrics/
 
       - name: Build embedded Ruby environment
         run: |


### PR DESCRIPTION
The `build-packages` job in `release.yml` was building from the repo root (`.`) instead of `./cmd/chef-migration-metrics/` where `main()` actually lives. This would cause the RPM/DEB package builds to fail.

This makes it consistent with the `build-archives` job which already uses the correct path.